### PR TITLE
Fix candidate handling on Firefox

### DIFF
--- a/src/js/api/provider/html5/providers/WebRTCLoader.js
+++ b/src/js/api/provider/html5/providers/WebRTCLoader.js
@@ -180,7 +180,7 @@ const WebRTCLoader = function (provider, webSocketUrl, loadCallback, errorTrigge
         }
 
         peerConnection.onicecandidate = function (e) {
-            if (e.candidate) {
+            if (e.candidate && candidate.candidate && candidate.candidate.length > 0) {
                 console.log("[onicecandidate]", e.candidate);
                 OvenPlayerConsole.log("WebRTCLoader send candidate to server : " + e.candidate);
 


### PR DESCRIPTION
Seems that OvenPlayer is suffering from this behavior (https://bugzilla.mozilla.org/show_bug.cgi?id=1540614) in Firefox - the spec seems to have changed and now an empty candidate is a valid way to signal end of gathering (see this https://w3c.github.io/webrtc-pc/#rtcpeerconnectioniceevent):

> An RTCIceTransport has finished gathering a generation of candidates, and is providing an end-of-candidates indication as defined by Section 8.2 of [TRICKLE-ICE]. This is indicated by candidate.candidate being set to an empty string. The candidate object should be signaled to the remote peer and passed into addIceCandidate like a typical ICE candidate, in order to provide the end-of-candidates indication to the remote peer.

Since the player does not have any end of candidate list mechanism, this should not be sent to the server, since the Oven Media Engine server then fails to parse the empty candidate, returns an error and everything breaks