### PR TITLE
Fix API .remove() example

### DIFF
--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1035,7 +1035,7 @@ This API can show or hide the player's control area.
 ### remove()
 
 ```
-playerInstance.stop()
+playerInstance.remove()
 ```
 
 This command removes the player and releases all resources.


### PR DESCRIPTION
This PR corrects the example code for the `remove()` API method. It contained `stop` instead of `remove` which was probably just a simple copy-paste oversight.

Thanks!