### PR TITLE
Issue #391 - destroy player even when videoElement not created

### DIFF
--- a/src/js/api/media/Manager.js
+++ b/src/js/api/media/Manager.js
@@ -65,7 +65,7 @@ const Manager = function(container, browserInfo){
     that.destroy = () =>{
         $container.removeChild();
         $container = null;
-        if(videoElement!=null && videoElement!='') {
+        if(videoElement!=null && videoElement!=='') {
             videoElement.srcObject = null;
         }
         videoElement = null;

--- a/src/js/api/media/Manager.js
+++ b/src/js/api/media/Manager.js
@@ -65,7 +65,9 @@ const Manager = function(container, browserInfo){
     that.destroy = () =>{
         $container.removeChild();
         $container = null;
-        videoElement.srcObject = null;
+        if(videoElement!=null && videoElement!='') {
+            videoElement.srcObject = null;
+        }
         videoElement = null;
     };
 


### PR DESCRIPTION
This will continue destroying the player instance even when videoElement hasn't been created yet.