### PR TITLE
fix: prevent vue3 component reload too frequently

### DIFF
--- a/packages/vue3/src/OvenPlayer.vue
+++ b/packages/vue3/src/OvenPlayer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, onUpdated } from 'vue';
+import { ref, watch, onMounted, onUnmounted } from 'vue';
 import OvenPlayer from 'ovenplayer';
 
 import type { OvenPlayerConfig, OvenPlayerInstance, OvenPlayerEvents } from 'ovenplayer';
@@ -179,10 +179,14 @@ onMounted(createPlayer);
 
 onUnmounted(removePlayer);
 
-onUpdated(() => {
-  removePlayer();
-  createPlayer();
-});
+watch(
+  () => props.config,
+  () => {
+    removePlayer();
+    createPlayer();
+  },
+  { deep: true }
+);
 </script>
 
 <template>


### PR DESCRIPTION
It fixed component recreate itself too frequently, only reload player when config changed.