### PR TITLE
Implement zoom panel for control scale of media container

### DIFF
--- a/src/js/api/Api.js
+++ b/src/js/api/Api.js
@@ -400,7 +400,22 @@ const Api = function (container) {
         OvenPlayerConsole.log("API : getPlaybackRate() ", currentProvider.getPlaybackRate());
         return currentProvider.getPlaybackRate();
     };
+    that.setZoomFactor = (zoomFactor) => {
+        if (!currentProvider) {
+            return null;
+        }
 
+        OvenPlayerConsole.log("API : setZoomFactor() ", zoomFactor);
+        return currentProvider.setZoomFactor(playerConfig.setZoomFactor(zoomFactor));
+    };
+    that.getZoomFactor = () => {
+        if (!currentProvider) {
+            return null;
+        }
+
+        OvenPlayerConsole.log("API : getZoomFactor() ", currentProvider.getZoomFactor());
+        return currentProvider.getZoomFactor();
+    };
     that.getPlaylist = () => {
         OvenPlayerConsole.log("API : getPlaylist() ", playlistManager.getPlaylist());
         return playlistManager.getPlaylist();

--- a/src/js/api/Configurator.js
+++ b/src/js/api/Configurator.js
@@ -37,6 +37,7 @@ const Configurator = function(options, provider){
             fullscreenOption: null,
             showBigPlayButton: true,
             doubleTapToSeek: false,
+            showZoomSettings: false,
         };
         const serialize = function (val) {
             if (val === undefined) {
@@ -165,7 +166,13 @@ const Configurator = function(options, provider){
         spec.playbackRate = playbackRate;
         return playbackRate;
     };
-
+    that.getZoomFactor =()=>{
+        return spec.zoomFactor;
+    };
+    that.setZoomFactor =(zoomFactor)=>{
+        spec.zoomFactor = zoomFactor;
+        return zoomFactor;
+    };
     that.getQualityLabel = () => {
         return spec.qualityLabel;
     };

--- a/src/js/api/constants.js
+++ b/src/js/api/constants.js
@@ -139,7 +139,8 @@ export const SYSTEM_TEXT = [
                 "quality" : "Quality",
                 "audioTrack" : "Audio",
                 "caption" : "Caption",
-                "display" : "Display"
+                "display" : "Display",
+                "zoom" : "Zoom"
             }
         },
         "api" : {
@@ -293,7 +294,8 @@ export const SYSTEM_TEXT = [
                 "quality" : "품질",
                 "audioTrack" : "오디오",
                 "caption" : "자막",
-                "display" : "표시"
+                "display" : "표시",
+                "zoom" : "Zoom"
             }
         },
         "api" : {
@@ -447,7 +449,8 @@ export const SYSTEM_TEXT = [
                 "quality" : "Jakość",
                 "audioTrack" : "Audio",
                 "caption" : "Podtytuł",
-                "display" : "Wyświetlacz"
+                "display" : "Wyświetlacz",
+                "zoom" : "Zoom"
             }
         },
         "api" : {

--- a/src/js/api/provider/html5/Provider.js
+++ b/src/js/api/provider/html5/Provider.js
@@ -50,6 +50,7 @@ const Provider = function (spec, playerConfig, onExtendedLoad) {
 
     listener = EventsListener(elVideo, that, ads ? ads.videoEndedCallback : null, playerConfig);
     elVideo.playbackRate = elVideo.defaultPlaybackRate = playerConfig.getPlaybackRate();
+    spec.zoomFactor = 1.0;
 
     const _load = (lastPlayPosition) => {
 
@@ -381,7 +382,12 @@ const Provider = function (spec, playerConfig, onExtendedLoad) {
         }
         return elVideo.playbackRate;
     };
-
+    that.getZoomFactor = () => {
+        return spec.zoomFactor;
+    };
+    that.setZoomFactor = (zoomFactor) => {
+        return spec.zoomFactor = zoomFactor;
+    };
     that.getSources = () => {
         if (!elVideo) {
             return [];

--- a/src/js/view/components/controls/settingButton.js
+++ b/src/js/view/components/controls/settingButton.js
@@ -15,7 +15,8 @@ let PANEL_TITLE = {
     "quality": "Quality",
     "audioTrack": "Audio",
     "caption": "Caption",
-    "display": "Display"
+    "display": "Display",
+    "zoom" : "Zoom"
 };
 const SettingButton = function ($container, api) {
     let panelManager = PanelManager();
@@ -51,6 +52,8 @@ const SettingButton = function ($container, api) {
 
         let framerate = api.getFramerate();
 
+        let allowZoom = playerConfig.showZoomSettings;
+
         if (currentSource) {
             let body = {
                 title: PANEL_TITLE.speed,
@@ -58,6 +61,16 @@ const SettingButton = function ($container, api) {
                 description: api.getPlaybackRate() + PANEL_TITLE.speedUnit,
                 panelType: "speed",
                 hasNext: true
+            };
+            panel.body.push(body);
+        }
+        if (allowZoom) {
+            let body = {
+                title : PANEL_TITLE.zoom,
+                value :  Math.round(api.getZoomFactor() * 100) + "%",
+                description :  Math.round(api.getZoomFactor() * 100) + "%",
+                panelType : "zoom",
+                hasNext : true
             };
             panel.body.push(body);
         }

--- a/src/js/view/components/controls/settingPanel/main.js
+++ b/src/js/view/components/controls/settingPanel/main.js
@@ -7,6 +7,7 @@ import LA$ from 'utils/likeA$';
 import _ from "utils/underscore";
 import sizeHumanizer from "utils/sizeHumanizer";
 import SpeedPanel from "view/components/controls/settingPanel/speedPanel";
+import ZoomPanel from "view/components/controls/settingPanel/zoomPanel";
 import SourcePanel from "view/components/controls/settingPanel/sourcePanel";
 import QualityPanel from "view/components/controls/settingPanel/qualityPanel";
 import AudioTrackPanel from "view/components/controls/settingPanel/audioTrackPanel";
@@ -19,6 +20,7 @@ import {AUDIO_TRACK_CHANGED} from "../../../../api/constants";
 
 let PANEL_TITLE = {
     "speed": "Speed",
+    "zoom": "Zoom",
     "speedUnit": "x",
     "source": "Source",
     "quality": "Quality",
@@ -63,6 +65,32 @@ const Panels = function ($container, api, data) {
                 };
                 panel.body.push(body);
             }
+
+        } else if (panelType === "zoom") {
+            let bodyIn = {
+                title : "+5%",
+                isCheck : false,
+                value : 0.05,
+                description : 0.05,
+                panelType : panelType
+            };
+            let body = {
+                title : "100%",
+                isCheck : false,
+                value : 0,
+                description : 1.0,
+                panelType : panelType
+            };
+            let bodyOut = {
+                title : "-5%",
+                isCheck : false,
+                value : -0.05,
+                description : -0.05,
+                panelType : panelType
+            };
+            panel.body.push(bodyIn);
+            panel.body.push(body);
+            panel.body.push(bodyOut);
 
         } else if (panelType === "source") {
             let sources = api.getSources();
@@ -203,6 +231,8 @@ const Panels = function ($container, api, data) {
             let panel = null;
             if (panelType === "speed") {
                 panel = SpeedPanel($container, api, extractSubPanelData(api, panelType));
+            } else if (panelType === "zoom") {
+                panel = ZoomPanel($container, api, extractSubPanelData(api, panelType));
             } else if (panelType === "source") {
                 panel = SourcePanel($container, api, extractSubPanelData(api, panelType));
             } else if (panelType === "quality") {

--- a/src/js/view/components/controls/settingPanel/zoomPanel.js
+++ b/src/js/view/components/controls/settingPanel/zoomPanel.js
@@ -1,0 +1,54 @@
+import OvenTemplate from 'view/engine/OvenTemplate';
+import PanelManager from "view/global/PanelManager";
+import LA$ from 'utils/likeA$';
+
+
+const ZoomPanel = function($container, api, data){
+    const $root = LA$(api.getContainerElement());
+    const media = $root.find(".op-media-element-container");
+
+    let panelManager = PanelManager();
+    let zoomProperty = "--mediaZoom";
+
+    data.setFront = function(isFront){
+        if(isFront){
+            $root.find("#"+data.id).removeClass("background");
+        }else{
+            $root.find("#"+data.id).addClass("background");
+        }
+    };
+    const onRendered = function($current, template){
+        //Do nothing
+    };
+    const onDestroyed = function(template){
+        //Do nothing
+    };
+    const events = {
+        "click .op-setting-item": function (event, $current, template) {
+            event.preventDefault();
+            let offset = LA$(event.currentTarget).attr("op-data-value");
+            let zoomFactor = api.getZoomFactor();
+
+            if (offset == 0) {
+                zoomFactor = 1.0;
+            } else {
+                zoomFactor = parseFloat(zoomFactor) + parseFloat(offset);
+            } 
+
+            if (zoomFactor <= 0 ) {
+                zoomFactor = 0
+            }
+
+            media.get().style.setProperty(zoomProperty, api.setZoomFactor(parseFloat(zoomFactor).toFixed(2)));
+        },
+        "click .op-setting-title" : function(event, $current, template){
+            event.preventDefault();
+            panelManager.removeLastItem();
+        }
+    };
+
+    return OvenTemplate($container, "ZoomPanel", api.getConfig(), data, events, onRendered, onDestroyed );
+
+};
+
+export default ZoomPanel;

--- a/src/js/view/engine/Templates.js
+++ b/src/js/view/engine/Templates.js
@@ -23,6 +23,7 @@ import TimeDisplayTemplate from 'view/components/controls/timeDisplayTemplate';
 import FullScreenButtonTemplate from 'view/components/controls/fullScreenButtonTemplate';
 import PanelsTemplate from 'view/components/controls/settingPanel/mainTemplate';
 import SpeedPanelTemplate from 'view/components/controls/settingPanel/mainTemplate';
+import ZoomPanelTemplate from 'view/components/controls/settingPanel/mainTemplate';
 import SourcePanelTemplate from 'view/components/controls/settingPanel/mainTemplate';
 import QualityPanelTemplate from 'view/components/controls/settingPanel/mainTemplate';
 import AudioTrackPanelTemplate from 'view/components/controls/settingPanel/mainTemplate';
@@ -52,6 +53,7 @@ const Templates = {
     FullScreenButtonTemplate,
     PanelsTemplate,
     SpeedPanelTemplate,
+    ZoomPanelTemplate,
     SourcePanelTemplate,
     QualityPanelTemplate,
     AudioTrackPanelTemplate,

--- a/src/stylesheet/ovenplayer.less
+++ b/src/stylesheet/ovenplayer.less
@@ -271,6 +271,7 @@
     top: 0px;
     width: 100%;
     height: 100%;
+    transform: scale(var(--mediaZoom));
 
     video {
       position: absolute;


### PR DESCRIPTION
I implemented the zoom functionality for the css property of the media container. 

For me personally I need to zoom when I stream content with unpopular aspect ratio and for those who are watching this button is useful to get rid of black bars on the top/bottom of the screen

I'm not sure if the code is correct, but as agreed in #300 Mr. @SangwonOh will help in bringing this feature to its final state. 