### PR TITLE
Update playback rate change event callback docs

### DIFF
--- a/docs/api-reference/events.md
+++ b/docs/api-reference/events.md
@@ -74,7 +74,11 @@ large(>992), medium(<992), small(<768), xsmall(<576)
 
 ### **on('playbackRateChanged')**&#x20;
 
-**Returns** Number **:** The new playback rate
+**Returns `Object`:**&#x20;
+
+| Params       | Type    | memo                  |
+| ------------ | ------- | --------------------- |
+| playbackRate | Number  | The new playback rate |
 
 Fired when the playback rate has been changed.
 


### PR DESCRIPTION
As [this line](https://github.com/AirenSoft/OvenPlayer/blob/master/src/js/api/provider/html5/Provider.js#L376) suggests (and as I've encountered when using current OvenPlayer version), the playback rate change callback actually passes an object argument, instead of plain number as current docs state.

This PR updates docs on that.