### PR TITLE
Update listener removal API docs

### DIFF
--- a/docs/api-reference/events.md
+++ b/docs/api-reference/events.md
@@ -25,10 +25,12 @@ player.once('EventName', function(data){
 ### Cancel a registered event
 
 ```
+// Remove all listeners for event type
 player.off('EventName');
+
+// Remove specific listener for event type
+player.off('EventName', listener)
 ```
-
-
 
 ### **on('ready')**
 


### PR DESCRIPTION
As I've got it working in a project for quite some time now, I'd love to see it in official docs (in order to follow-up with types update on DefinitelyTyped).

The `EventEmitter` allows removal of a single listener - if there is no reason why it's not mentioned in docs, I say let's add it.