### PR TITLE
Add HTMLElement as supported type for container

### DIFF
--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -23,10 +23,10 @@ const player = OvenPlayer.create(container, options);
 
 {% tabs %}
 {% tab title="Request" %}
-| Params    | Type   | Memo                                        |
-| --------- | ------ | ------------------------------------------- |
-| container | String | DOM Element                                 |
-| options   | Object | Please see the _**Options**_ section below. |
+| Params    | Type                  | Memo                                        |
+| --------- | ------                | ------------------------------------------- |
+| container | String \| HTMLElement | DOM Element                                 |
+| options   | Object                | Please see the _**Options**_ section below. |
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
This doc PR updates the accepted types to `OvenPlayer.create` to include [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) as it's supported by the [validator](https://github.com/AirenSoft/OvenPlayer/blob/master/src/js/utils/validator.js#L38).

I've long been using it this way, but ran into some type errors when incorporating [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ovenplayer/index.d.ts#L4). I figured the docs should reflect the correct state first before make the type adjustment.