### PR TITLE
Allow disable auto hide when showControls

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -409,10 +409,11 @@ const View = function($container){
             }
         }
 
-        api.showControls = function (show) {
+        api.showControls = function (show, keepOpen) {
             if (show) {
                 $playerRoot.removeClass("op-no-controls");
-                setHide(false, true);
+                let autoHide = !keepOpen
+                setHide(false, autoHide);
             } else {
                 $playerRoot.addClass("op-no-controls");
             }


### PR DESCRIPTION
Hi there 👋 

I am working on a project where I would like the controls to stay open after another action is performed that calls `showControls`. I suggest adding an additional optional argument that allows a consumer to disable autoHide when calling `showControls`.

Usage would be: 
`showControls(true, true)` -> Show controls and don't auto hide.
`showControls(true)` -> Show controls and auto hide.

I am happy to take feedback on this! 
Thank you for considering this. 