### PR TITLE
Refactor quality panel: single active selection + localized 'Auto' label

### DIFF
--- a/src/js/api/constants.js
+++ b/src/js/api/constants.js
@@ -135,6 +135,9 @@ export const SYSTEM_TEXT = [
         "low_latency_p2p": "Sub-Second Latency P2P",
       },
       "playlist": "Playlist",
+      "quality": {
+        "auto": "Auto"
+      },
       "setting": {
         "title": "Settings",
         "speed": "Speed",
@@ -295,6 +298,9 @@ export const SYSTEM_TEXT = [
         "low_latency_p2p": "초저지연 P2P",
       },
       "playlist": "플레이리스트",
+      "quality": {
+        "auto": "자동"
+      },
       "setting": {
         "title": "설정",
         "speed": "재생 속도",
@@ -455,6 +461,9 @@ export const SYSTEM_TEXT = [
         "low_latency_p2p": "Transmisja z niskim opóźnieniem P2P",
       },
       "playlist": "Playlista",
+      "quality": {
+        "auto": "Auto"
+      },
       "setting": {
         "title": "Ustawienia",
         "speed": "Prędkość",

--- a/src/js/view/components/controls/settingPanel/main.js
+++ b/src/js/view/components/controls/settingPanel/main.js
@@ -106,16 +106,17 @@ const Panels = function ($container, api, data) {
 
         } else if (panelType === "quality") {
             let qualityLevels = api.getQualityLevels();
+            let isQualityCheck = api.isAutoQuality();
             panel.body.push({
-                title: "AUTO",
-                isCheck: api.isAutoQuality(),
+                title: playerConfig.systemText.ui.quality.auto,
+                isCheck: isQualityCheck,
                 value: "AUTO",
                 panelType: panelType
             });
             for (let i = 0; i < qualityLevels.length; i++) {
                 let body = {
                     title: qualityLevels[i].label,
-                    isCheck: api.getCurrentQuality() === i,
+                    isCheck: !isQualityCheck && api.getCurrentQuality() === i,
                     value: i,
                     panelType: panelType
                 };

--- a/src/js/view/components/controls/settingPanel/qualityPanel.js
+++ b/src/js/view/components/controls/settingPanel/qualityPanel.js
@@ -31,7 +31,7 @@ const QualityPanel = function($container, api, data){
                     if( $panel.find(".op-setting-item-checked").hasClass("op-show")){
                         $panel.find(".op-setting-item-checked").removeClass("op-show");
                     }
-                    if(newQuality === parseInt($panel.attr("op-data-value"))){
+                    if(!data.isAuto && newQuality === parseInt($panel.attr("op-data-value"))){
                         $panel.find(".op-setting-item-checked").addClass("op-show");
                     }
                     if(data.isAuto && $panel.attr("op-data-value") === "AUTO"){


### PR DESCRIPTION
### Summary
Improves the logic and UI clarity of the QualityPanel component by ensuring only one selection is shown as active, and introduces localization support for the 'Auto' label.

### What’s changed
- Updated logic in `QualityPanel` so that only **one** quality option is visibly active at a time.
  - If AUTO mode is active → only `Auto` is checked.
  - If manual quality is selected → only that specific level is checked.
- Modified `Panels` component to reflect the same logic when generating panel items.
- Replaced hardcoded `"AUTO"` string with localized `systemText.ui.quality.auto` value.
- Adjusted English label from `"AUTO"` to `"Auto"` for consistency.
- Added localization for:
  - 🇰🇷 Korean: `"자동"`
  - 🇵🇱 Polish: `"Auto"`

### Result
The quality panel now shows a clear, localized and accurate active selection. This improves user experience and supports multilingual UI.

### Tested
- Switching between AUTO and manual qualities
- Confirmed proper highlighting behavior
- Verified localization is applied
