### PR TITLE
fix PLAYER_ZOOM_CAHNGED event listener

### DIFF
--- a/src/js/view/components/controls/settingPanel/main.js
+++ b/src/js/view/components/controls/settingPanel/main.js
@@ -232,6 +232,7 @@ const Panels = function ($container, api, data) {
     const onDestroyed = function (template) {
         api.off(CONTENT_LEVEL_CHANGED, null, template);
         api.off(AUDIO_TRACK_CHANGED, null, template);
+        api.off(PLAYER_ZOOM_CAHNGED, null, template);
     };
     const events = {
         "click .op-setting-item": function (event, $current, template) {


### PR DESCRIPTION
Stale event listener was causing TypeError when accessing detached DOM elements after reopening the settings panel.

Properly cleanup `PLAYER_ZOOM_CHANGED` event listener in settings panel