### PR TITLE
Remove global assignment of HLS instance

### DIFF
--- a/src/js/api/provider/html5/providers/Hls.js
+++ b/src/js/api/provider/html5/providers/Hls.js
@@ -60,8 +60,6 @@ const HlsProvider = function (element, playerConfig, adTagUrl) {
 
         hls = new Hls(hlsConfig);
 
-        window.op_hls = hls;
-
         hls.attachMedia(element);
 
         let spec = {


### PR DESCRIPTION
Eliminate the assignment of the HLS instance to the global window object to improve encapsulation and prevent potential conflicts.