### PR TITLE
Added `autoMuteRetryOnNotAllowed` setting and related functionality.

### DIFF
--- a/src/js/api/Configurator.js
+++ b/src/js/api/Configurator.js
@@ -42,7 +42,8 @@ const Configurator = function (options, provider) {
             legacyUI: false,
             parseStream: {
                 enabled: false
-            }
+            },
+            autoMuteRetryOnNotAllowed: false,
         };
         const serialize = function (val) {
             if (val === undefined) {

--- a/src/js/api/provider/html5/Provider.js
+++ b/src/js/api/provider/html5/Provider.js
@@ -334,6 +334,13 @@ const Provider = function (spec, playerConfig, onExtendedLoad) {
                         OvenPlayerConsole.log("Provider : video play error", error.message);
 
                         isPlayingProcessing = false;
+
+                        // Auto mute and retry play if autoMuteRetryOnNotAllowed config is enabled
+                        if (error.name === 'NotAllowedError' && playerConfig.getConfig().autoMuteRetryOnNotAllowed) {
+                            that.setMute(true);
+                            that.play(true);
+                        }
+
                         /*
                         if(!mutedPlay){
                             that.setMute(true);


### PR DESCRIPTION
Use this setting to automatically mute and attempt to play again when encountering a browser NotAllowedError during autoplay or when calling the .play method.

Since the NotAllowedError does not appear to propagate events upward, it prevents me from implementing the auto-play functionality I need to achieve externally—specifically, muting and resuming playback when encountering blocking policies. Therefore, I have introduced this change.