### PR TITLE
docs: rewrite legacy GitBook URLs to ovenmedialabs.com /docs/ovenplayer paths

### DIFF
--- a/docs-site/intro.md
+++ b/docs-site/intro.md
@@ -94,7 +94,7 @@ $ npm install ovenplayer-react
 
 ## Quick Start
 
-Below is a list of simple OvenPlayer initialization methods for each situation. For detailed options when initializing the OvenPlayer, please refer to the [Initialization](https://docs.ovenplayer.com/initialization) chapter.
+Below is a list of simple OvenPlayer initialization methods for each situation. For detailed options when initializing the OvenPlayer, please refer to the [Initialization](/docs/ovenplayer/initialization) chapter.
 
 ### Basic Concept
 
@@ -249,7 +249,7 @@ If you need direct access to the internal OvenPlayer instance or want to re-crea
 
 ### Initialize for OME
 
-To play Sub-Second Latency Stream of OvenMediaEngine, set the source `type` to `webrtc` and set the `file` to the WebRTC Signaling URL with OvenMediaEngine. An explanation of the WebRTC Signaling URL can be found [here](https://docs.ovenmediaengine.com/getting-started#playback).
+To play Sub-Second Latency Stream of OvenMediaEngine, set the source `type` to `webrtc` and set the `file` to the WebRTC Signaling URL with OvenMediaEngine. An explanation of the WebRTC Signaling URL can be found [here](/docs/ome/getting-started#playback).
 
 ```markup
 <!DOCTYPE html>

--- a/docs-site/intro.md
+++ b/docs-site/intro.md
@@ -94,7 +94,7 @@ $ npm install ovenplayer-react
 
 ## Quick Start
 
-Below is a list of simple OvenPlayer initialization methods for each situation. For detailed options when initializing the OvenPlayer, please refer to the [Initialization](/docs/ovenplayer/initialization) chapter.
+Below is a list of simple OvenPlayer initialization methods for each situation. For detailed options when initializing the OvenPlayer, please refer to the [Initialization](initialization.md) chapter.
 
 ### Basic Concept
 
@@ -249,7 +249,7 @@ If you need direct access to the internal OvenPlayer instance or want to re-crea
 
 ### Initialize for OME
 
-To play Sub-Second Latency Stream of OvenMediaEngine, set the source `type` to `webrtc` and set the `file` to the WebRTC Signaling URL with OvenMediaEngine. An explanation of the WebRTC Signaling URL can be found [here](/docs/ome/getting-started#playback).
+To play Sub-Second Latency Stream of OvenMediaEngine, set the source `type` to `webrtc` and set the `file` to the WebRTC Signaling URL with OvenMediaEngine. An explanation of the WebRTC Signaling URL can be found [here](https://ovenmedialabs.com/docs/ome/getting-started#playback).
 
 ```markup
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary

Rewrite two in-tree links in `docs-site/intro.md` that pointed at the legacy `airensoft.gitbook.io` / `docs.ovenplayer.com` hosts — they now point at the consolidated Docusaurus pages on ovenmedialabs.com under `/docs/ovenplayer/...`.

## Why

ovenmedialabs.com is becoming the single home for the OvenPlayer manual. The old hosts will be redirected to it at the DNS layer during cutover, but in-tree links should already be relative to the new home so the manual reads cleanly when viewed locally, on GitHub, or as a static build — without depending on the external redirect layer.