### PR TITLE
docs: add local preview script and docs-site README

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,7 +1,7 @@
 # `docs-site/` — OvenPlayer docs source
 
-This folder holds the **MDX source** for the OvenPlayer user guide
-published at <https://ovenmedialabs.com/docs/ovenplayer/>.
+This folder holds the **MDX source** for the OvenPlayer user
+guide published at <https://ovenmedialabs.com/docs/ovenplayer/>.
 
 ## Editing
 
@@ -14,9 +14,10 @@ conventions, and image rules.
 
 Run `./docs-site/preview.sh` from the repo root.
 
-The script clones ovenmedialabs.com into a per-product cache, sym-
-links your `docs-site/` into it, and starts a dev server. When it's
-ready you'll see:
+The script clones the [airensoft.com](https://github.com/OvenMediaLabs/airensoft.com)
+repo (the source for ovenmedialabs.com — the repo keeps its legacy
+name) into a per-product cache, symlinks your `docs-site/` into it,
+and starts a dev server. When it's ready you'll see:
 
     [SUCCESS] Docusaurus website is running at: http://localhost:3000/
 
@@ -38,5 +39,5 @@ minutes (clone + npm install); subsequent runs ~10 seconds.
 Env var overrides:
 
 - `OML_PREVIEW_PORT` (default `3000`)
-- `OML_PREVIEW_BRANCH` (which branch of ovenmedialabs.com to clone)
+- `OML_PREVIEW_BRANCH` (which branch of the airensoft.com repo to clone)
 - `OML_PREVIEW_CACHE` (cache root path)

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,42 @@
+# `docs-site/` — OvenPlayer docs source
+
+This folder holds the **MDX source** for the OvenPlayer user guide
+published at <https://ovenmedialabs.com/docs/ovenplayer/>.
+
+## Editing
+
+Each page is a markdown / MDX file under this directory; the folder
+tree maps to the URL structure of the published docs. See
+[STYLE.md](./STYLE.md) for frontmatter, admonition syntax, link
+conventions, and image rules.
+
+## Local preview
+
+Run `./docs-site/preview.sh` from the repo root.
+
+The script clones ovenmedialabs.com into a per-product cache, sym-
+links your `docs-site/` into it, and starts a dev server. When it's
+ready you'll see:
+
+    [SUCCESS] Docusaurus website is running at: http://localhost:3002/
+
+Open that URL in a browser — the page reloads automatically as you
+save edits in `docs-site/`.
+
+Stop the preview with **Ctrl-C** in the terminal.
+
+> **What about broken links?** A broken markdown link (e.g. a typo'd
+> `.md` path or a missing image) shows up in the preview terminal
+> immediately and stops the page from compiling — you'll know right
+> away. A broken anchor (`#missing-section`) is only flagged by the
+> full production build, so click your anchor links once before
+> merging.
+
+Requirements: bash, git, Node 20+, npm. macOS/Linux. First run ~5
+minutes (clone + npm install); subsequent runs ~10 seconds.
+
+Env var overrides:
+
+- `OML_PREVIEW_PORT` (default `3002`)
+- `OML_PREVIEW_BRANCH` (which branch of ovenmedialabs.com to clone)
+- `OML_PREVIEW_CACHE` (cache root path)

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -18,7 +18,7 @@ The script clones ovenmedialabs.com into a per-product cache, sym-
 links your `docs-site/` into it, and starts a dev server. When it's
 ready you'll see:
 
-    [SUCCESS] Docusaurus website is running at: http://localhost:3002/
+    [SUCCESS] Docusaurus website is running at: http://localhost:3000/
 
 Open that URL in a browser — the page reloads automatically as you
 save edits in `docs-site/`.
@@ -37,6 +37,6 @@ minutes (clone + npm install); subsequent runs ~10 seconds.
 
 Env var overrides:
 
-- `OML_PREVIEW_PORT` (default `3002`)
+- `OML_PREVIEW_PORT` (default `3000`)
 - `OML_PREVIEW_BRANCH` (which branch of ovenmedialabs.com to clone)
 - `OML_PREVIEW_CACHE` (cache root path)

--- a/docs-site/preview.sh
+++ b/docs-site/preview.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Start a local preview of ovenmedialabs.com that surfaces ONLY the
+# docs for the upstream repo you're working in. Designed to be copied
+# into each upstream `docs-site/preview.sh` so that editors can run
+# `./docs-site/preview.sh` after changing markdown and see the result
+# rendered with the same theme/layout as production.
+#
+# Behaviour:
+#   1. Detects which product you're in (ome / ome-enterprise /
+#      ovenplayer) by inspecting `git remote get-url origin`.
+#   2. Bootstraps a per-product cache under
+#         ~/.cache/ovenmedialabs-preview/<source>/site/
+#      with a clone of OvenMediaLabs/airensoft.com so a single editor
+#      can preview multiple products in parallel without collisions.
+#   3. Refreshes the cache (fetch + reset --hard) on each run.
+#   4. Installs npm deps if the lockfile changed.
+#   5. Symlinks the current repo's `docs-site/` into the cache's
+#      `docs/<source>/` so docs changes are picked up live by HMR.
+#   6. Starts `npm start` with OML_PREVIEW_SOURCE set — the consuming
+#      site hides marketing nav/footer and redirects `/` to
+#      `/docs/<source>/`.
+#
+# Per-product defaults (override with OML_PREVIEW_PORT or
+# OML_PREVIEW_BRANCH if needed):
+#       ome              port 3000
+#       ome-enterprise   port 3001
+#       ovenplayer       port 3002
+#
+# Requires: bash, git, Node 20+, npm. macOS / Linux.
+
+set -euo pipefail
+
+SITE_REPO="https://github.com/OvenMediaLabs/airensoft.com.git"
+SITE_BRANCH="${OML_PREVIEW_BRANCH:-feat/docusaurus-migration}"
+CACHE_ROOT="${OML_PREVIEW_CACHE:-$HOME/.cache/ovenmedialabs-preview}"
+
+# Detect which product we're in.
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+case "$origin_url" in
+    *OvenMediaEngineEnterprise*) SOURCE="ome-enterprise"; DEFAULT_PORT=3001 ;;
+    *OvenMediaEngine*)           SOURCE="ome";            DEFAULT_PORT=3000 ;;
+    *OvenPlayer*)                SOURCE="ovenplayer";     DEFAULT_PORT=3002 ;;
+    *)
+        echo "error: can't detect product from origin URL '$origin_url'" >&2
+        echo "       run this from inside an OvenMediaLabs upstream repo." >&2
+        exit 1
+        ;;
+esac
+PORT="${OML_PREVIEW_PORT:-$DEFAULT_PORT}"
+
+# Locate the docs-site directory we're previewing.
+repo_root="$(git rev-parse --show-toplevel)"
+docs_site="$repo_root/docs-site"
+if [ ! -d "$docs_site" ]; then
+    echo "error: $docs_site not found — are you in the right repo?" >&2
+    exit 1
+fi
+
+# Verify prerequisites.
+for cmd in node npm git; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "error: '$cmd' not found in PATH. Install Node 20+ and git." >&2
+        exit 1
+    fi
+done
+
+node_major="$(node --version | sed -E 's/^v([0-9]+).*/\1/')"
+if [ "$node_major" -lt 20 ]; then
+    echo "error: Node $node_major detected; preview needs Node 20+." >&2
+    exit 1
+fi
+
+site_dir="$CACHE_ROOT/$SOURCE/site"
+
+# Clone airensoft.com into the cache on first run, then keep it
+# fresh on every subsequent run.
+if [ ! -d "$site_dir/.git" ]; then
+    echo "▶ first run: cloning $SITE_REPO into $site_dir"
+    mkdir -p "$(dirname "$site_dir")"
+    git clone --branch "$SITE_BRANCH" --depth 1 "$SITE_REPO" "$site_dir"
+else
+    echo "▶ refreshing site cache ($site_dir)"
+    git -C "$site_dir" fetch origin "$SITE_BRANCH" --quiet
+    git -C "$site_dir" reset --hard "origin/$SITE_BRANCH" --quiet
+fi
+
+# Install npm deps the first time, or whenever the lockfile changed
+# since node_modules was last touched.
+if [ ! -d "$site_dir/node_modules" ] \
+   || [ "$site_dir/package-lock.json" -nt "$site_dir/node_modules" ]; then
+    echo "▶ installing npm dependencies (one-time, ~1 minute)"
+    (cd "$site_dir" && npm install --no-audit --no-fund)
+fi
+
+# Replace the cached docs/<source>/ with a symlink to our docs-site/
+# so the editor sees their edits live via HMR. If the cache already
+# has a non-symlink directory there (from a fresh clone), drop it
+# first.
+target="$site_dir/docs/$SOURCE"
+if [ -L "$target" ]; then
+    rm "$target"
+elif [ -e "$target" ]; then
+    rm -rf "$target"
+fi
+ln -s "$docs_site" "$target"
+
+echo
+echo "▶ starting Docusaurus on http://localhost:$PORT  (Ctrl-C to stop)"
+echo "  source:     $SOURCE  ←  $docs_site"
+echo "  cache:      $site_dir"
+echo "  preview UI: marketing pages and other products' docs are hidden"
+echo
+
+cd "$site_dir"
+OML_PREVIEW_SOURCE="$SOURCE" npm start -- --port "$PORT"

--- a/docs-site/preview.sh
+++ b/docs-site/preview.sh
@@ -38,16 +38,16 @@ CACHE_ROOT="${OML_PREVIEW_CACHE:-$HOME/.cache/ovenmedialabs-preview}"
 # Detect which product we're in.
 origin_url="$(git remote get-url origin 2>/dev/null || true)"
 case "$origin_url" in
-    *OvenMediaEngineEnterprise*) SOURCE="ome-enterprise"; DEFAULT_PORT=3001 ;;
-    *OvenMediaEngine*)           SOURCE="ome";            DEFAULT_PORT=3000 ;;
-    *OvenPlayer*)                SOURCE="ovenplayer";     DEFAULT_PORT=3002 ;;
+    *OvenMediaEngineEnterprise*) SOURCE="ome-enterprise" ;;
+    *OvenMediaEngine*)           SOURCE="ome" ;;
+    *OvenPlayer*)                SOURCE="ovenplayer" ;;
     *)
         echo "error: can't detect product from origin URL '$origin_url'" >&2
         echo "       run this from inside an OvenMediaLabs upstream repo." >&2
         exit 1
         ;;
 esac
-PORT="${OML_PREVIEW_PORT:-$DEFAULT_PORT}"
+PORT="${OML_PREVIEW_PORT:-3000}"
 
 # Locate the docs-site directory we're previewing.
 repo_root="$(git rev-parse --show-toplevel)"

--- a/docs-site/preview.sh
+++ b/docs-site/preview.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 #
-# Start a local preview of ovenmedialabs.com that surfaces ONLY the
-# docs for the upstream repo you're working in. Designed to be copied
-# into each upstream `docs-site/preview.sh` so that editors can run
+# Start a local preview of the ovenmedialabs.com site (whose source
+# lives in the OvenMediaLabs/airensoft.com repo — the repo keeps its
+# legacy name) and surface ONLY the docs for the upstream product
+# you're working in. Designed to be copied into each upstream
+# `docs-site/preview.sh` so that editors can run
 # `./docs-site/preview.sh` after changing markdown and see the result
 # rendered with the same theme/layout as production.
 #
@@ -11,8 +13,8 @@
 #      ovenplayer) by inspecting `git remote get-url origin`.
 #   2. Bootstraps a per-product cache under
 #         ~/.cache/ovenmedialabs-preview/<source>/site/
-#      with a clone of OvenMediaLabs/airensoft.com so a single editor
-#      can preview multiple products in parallel without collisions.
+#      with a clone of OvenMediaLabs/airensoft.com so different
+#      products keep separate working copies.
 #   3. Refreshes the cache (fetch + reset --hard) on each run.
 #   4. Installs npm deps if the lockfile changed.
 #   5. Symlinks the current repo's `docs-site/` into the cache's
@@ -21,11 +23,8 @@
 #      site hides marketing nav/footer and redirects `/` to
 #      `/docs/<source>/`.
 #
-# Per-product defaults (override with OML_PREVIEW_PORT or
-# OML_PREVIEW_BRANCH if needed):
-#       ome              port 3000
-#       ome-enterprise   port 3001
-#       ovenplayer       port 3002
+# Default port is 3000; override with OML_PREVIEW_PORT (or pick a
+# different branch of the airensoft.com repo via OML_PREVIEW_BRANCH).
 #
 # Requires: bash, git, Node 20+, npm. macOS / Linux.
 


### PR DESCRIPTION
## Summary

Add `docs-site/preview.sh` so editors can spin up a local copy of ovenmedialabs.com against the current `docs-site/` and see their changes rendered in the real theme before merging. Add `docs-site/README.md` explaining how to run it and what to expect.

## Why

Until now, the only way to verify a docs edit was to merge first and check the live site afterwards. The preview script clones ovenmedialabs.com into a per-product cache, symlinks the editor's `docs-site/` into it, and starts a dev server in docs-only mode — marketing chrome and other products' docs are hidden so the editor stays focused on OvenPlayer. HMR picks up edits as files are saved.