### PR TITLE
ci: point check-docs-build at main now that the site has cut over

### DIFF
--- a/.github/workflows/check-docs-build.yml
+++ b/.github/workflows/check-docs-build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: OvenMediaLabs/airensoft.com
-          ref: feat/docusaurus-migration
+          ref: main
           path: site
 
       - name: Stage this PR's docs-site/ into the site


### PR DESCRIPTION
The feat/docusaurus-migration branch was used while the consuming ovenmedialabs.com site lived only there. It's merged to main now.