### PR TITLE
feat: add sidebar metadata for ovenmedialabs.com autogeneration

### DIFF
--- a/docs/api-reference/_category_.json
+++ b/docs/api-reference/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "API Reference",
+  "position": 6,
+  "customProps": {
+    "sidebarHeader": true
+  }
+}

--- a/docs/examples/_category_.json
+++ b/docs/examples/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Examples",
+  "position": 8,
+  "customProps": {
+    "sidebarHeader": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add `_category_.json` to `docs/api-reference/` and `docs/examples/` with `customProps.sidebarHeader: true`.

## Why
ovenmedialabs.com is switching to a fully autogenerated sidebar derived from this repo's `docs/` tree. These two folders need explicit metadata so the site renders them as section dividers above their child pages, matching the existing OvenPlayer sidebar design.