### PR TITLE
docs: add SEO/AIO meta descriptions to docs frontmatter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,13 @@ description: How to initialize OvenPlayer on a web page.
 
 - `title` — page title shown in browser tab and as H1
 - `sidebar_position` — order within the section (smaller = higher)
-- `description` — SEO meta description; appears in search snippets
+- `description` — **required.** A one-sentence meta description
+  (~120–155 chars) stating what the page covers; include "OvenPlayer".
+  This is what search engines show in snippets and what AI answer
+  engines quote, so **always write one.** If omitted, the site falls
+  back to a low-quality auto-excerpt of the first line (often a bare
+  heading like "How to write code"), which hurts search and AI
+  discoverability.
 - `slug` (optional) — override URL path; useful for `intro.md` (`slug: /`)
 
 ### Admonitions

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1,5 +1,6 @@
 ---
 title: API
+description: "OvenPlayer JavaScript API reference: control playback, query state, and manage sources and captions via player instance methods."
 sidebar_position: 6
 ---
 

--- a/docs/api-reference/events.md
+++ b/docs/api-reference/events.md
@@ -1,5 +1,6 @@
 ---
 title: Event
+description: "OvenPlayer event reference: subscribe with player.on()/once() and remove listeners with off() to react to playback state changes."
 sidebar_position: 7
 ---
 

--- a/docs/builds.md
+++ b/docs/builds.md
@@ -1,5 +1,6 @@
 ---
 title: Builds
+description: "Build OvenPlayer from source with npm and webpack, including production and watch-mode development builds."
 sidebar_position: 4
 ---
 

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -1,5 +1,6 @@
 ---
 title: UI Customize
+description: "Customize the OvenPlayer UI with CSS skinning — change the accent color and restyle controls via CSS variables."
 sidebar_position: 5
 ---
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,5 +1,6 @@
 ---
 title: Error Handling
+description: "How OvenPlayer detects playback errors and performs automatic recovery and protocol fallback across WebRTC, HLS, and DASH."
 sidebar_position: 3
 ---
 

--- a/docs/examples/ads.md
+++ b/docs/examples/ads.md
@@ -1,5 +1,6 @@
 ---
 title: Ads
+description: "Monetize OvenPlayer with ads: VAST 4/3/2, VPAID 2, and VMAP 1.0.1 are supported through the adTagUrl option."
 sidebar_position: 10
 ---
 

--- a/docs/examples/captions.md
+++ b/docs/examples/captions.md
@@ -1,5 +1,6 @@
 ---
 title: Captions
+description: "Add subtitles to OvenPlayer: register WebVTT, SRT, and SMI caption tracks directly without conversion."
 sidebar_position: 9
 ---
 

--- a/docs/examples/playlist.md
+++ b/docs/examples/playlist.md
@@ -1,5 +1,6 @@
 ---
 title: Playlist
+description: "Configure OvenPlayer playback sources — single source, multi-protocol/resolution sources, and playlists with automatic fallback."
 sidebar_position: 8
 ---
 

--- a/docs/examples/runs-on-webserver.md
+++ b/docs/examples/runs-on-webserver.md
@@ -1,5 +1,6 @@
 ---
 title: Run-on WebServer
+description: "Run OvenPlayer from a web server: install Nginx, deploy the player files, and serve a working example over HTTP/HTTPS."
 sidebar_position: 11
 ---
 

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -1,5 +1,6 @@
 ---
 title: Initialization
+description: "Create and access an OvenPlayer instance with OvenPlayer.create(), and configure playback through its initialization options."
 sidebar_position: 2
 ---
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,7 @@
 ---
 slug: /
 title: Introduction
+description: "OvenPlayer is an open-source HTML5 player for sub-second latency streaming from OvenMediaEngine over WebRTC, with HLS and LL-DASH fallback."
 sidebar_position: 1
 ---
 


### PR DESCRIPTION
## Summary

- Add an authored `description:` to the frontmatter of docs pages that previously had none (or only a weak Docusaurus first-line auto-excerpt).
- Document `description` as required in the docs contributor guide.

## Why

Most docs shipped with no authored meta description; the consuming ovenmedialabs.com site then fell back to low-quality first-line excerpts, weakening search snippets and AI answer extraction.
